### PR TITLE
Change the authentication mode of ocp-express and obagent

### DIFF
--- a/common/src/main/java/com/oceanbase/ocp/common/util/time/TimeUtils.java
+++ b/common/src/main/java/com/oceanbase/ocp/common/util/time/TimeUtils.java
@@ -15,6 +15,7 @@ package com.oceanbase.ocp.common.util.time;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -156,6 +157,13 @@ public class TimeUtils {
 
     public static OffsetDateTime toUtc(Instant instant) {
         return usToUtc(toUs(instant));
+    }
+
+    public static String getCurrentDate(String format) {
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter dataFormat = DateTimeFormatter.ofPattern(format);
+        String date = dataFormat.format(now);
+        return date;
     }
 
 }

--- a/library/command-executor/src/main/java/com/oceanbase/ocp/executor/internal/connector/ConnectProperties.java
+++ b/library/command-executor/src/main/java/com/oceanbase/ocp/executor/internal/connector/ConnectProperties.java
@@ -12,6 +12,8 @@
 
 package com.oceanbase.ocp.executor.internal.connector;
 
+import java.util.Map;
+
 import com.oceanbase.ocp.executor.internal.auth.Authentication;
 import com.oceanbase.ocp.executor.internal.util.ValidateUtils;
 
@@ -42,6 +44,8 @@ public class ConnectProperties {
      * Agent auth info.
      */
     private Authentication authentication;
+
+    private Map<String, Object> extHttpHeaders;
 
     public void validate() {
         ValidateUtils.requireNotNull(authentication, "authentication");

--- a/library/command-executor/src/main/java/com/oceanbase/ocp/executor/internal/util/DigestSignature.java
+++ b/library/command-executor/src/main/java/com/oceanbase/ocp/executor/internal/util/DigestSignature.java
@@ -1,0 +1,60 @@
+package com.oceanbase.ocp.executor.internal.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.oceanbase.ocp.executor.internal.auth.http.DigestAuthConfig;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Validate;
+
+@Data
+@Builder
+@Slf4j
+public class DigestSignature {
+
+    private String date;
+
+    private String method;
+
+    private String url;
+
+    private String contentType;
+
+    private String traceId;
+
+    private DigestAuthConfig authConfig;
+
+    public String getAuthorizationHeader() {
+        String username = authConfig.getUsername();
+        String password = authConfig.getPassword();
+        String signature = method + "\n" + url + "\n" + contentType + "\n" + date + "\n" + traceId;
+        String sign = Base64.getEncoder().encodeToString(
+                hmacSha1(password, signature.getBytes(StandardCharsets.UTF_8)));
+        String authorization = "OCP-HMACSHA1 " + username + ":" + sign;
+        return authorization;
+    }
+
+    public static byte[] hmacSha1(String key, byte[] content) {
+        try {
+            Validate.notEmpty(key, "cannot be null or empty.");
+            Validate.notNull(content, "content");
+            Validate.isTrue(content.length != 0, "content cannot be empty.");
+
+            Mac mac = Mac.getInstance("HmacSHA1");
+            mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA1"));
+            return mac.doFinal(content);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Not supported signature method HmacSHA1", e);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException("Failed to calculate the signature", e);
+        }
+    }
+}

--- a/server/src/main/java/com/oceanbase/ocp/config/OcpExpressInitializer.java
+++ b/server/src/main/java/com/oceanbase/ocp/config/OcpExpressInitializer.java
@@ -168,7 +168,7 @@ public class OcpExpressInitializer {
         // Save global agent password to vault
         agentCredentialOperator.saveAgentCredential(initProperties.getAgentUsername(),
                 initProperties.getAgentPassword());
-        exporterRequestHelper.setBasicAuth(initProperties.getAgentUsername(), initProperties.getAgentPassword());
+        exporterRequestHelper.setDigestAuth(initProperties.getAgentUsername(), initProperties.getAgentPassword());
         agentExecutorFactory.setAuthInfo(initProperties.getAgentUsername(), initProperties.getAgentPassword());
         obAgentService.initAgent(initAgentParams);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Change the authentication mode of ocp-express and obagent


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
For security reasons, the authentication modes of ocp-express and obagent are changed from basic to digest。