### PR TITLE
🐞 fix(frontend/build): Disable antd auto locale to avoid build error

### DIFF
--- a/frontend/config/config.ts
+++ b/frontend/config/config.ts
@@ -64,7 +64,9 @@ export default defineConfig({
   mfsu: {},
   locale: {
     default: 'zh-CN',
-    antd: true,
+    // disable antd locale import in umi plugin-locale to avoid build error
+    // issue: https://github.com/oceanbase/ocp-express/pull/22
+    antd: false,
     title: false,
   },
   // esbuild: {},


### PR DESCRIPTION

![image](https://github.com/oceanbase/ocp-express/assets/14918822/7f80141a-a804-4909-9404-546013745b3e)

![image](https://github.com/oceanbase/ocp-express/assets/14918822/05123b6c-79a6-4369-831e-ec90555520a9)
